### PR TITLE
Fix xmax typos in API docs

### DIFF
--- a/templates/api_v1.html
+++ b/templates/api_v1.html
@@ -31,7 +31,7 @@
 
 <h3>Search by Bounding Box</h3>
 
-<pre>http://gitspatial.com/:user_name/:repo_name/:feature_set_name?bbox=:xmin,:ymin,:ymax,:ymax</pre>
+<pre>http://gitspatial.com/:user_name/:repo_name/:feature_set_name?bbox=:xmin,:ymin,:xmax,:ymax</pre>
 
 <h4>Parameters</h4>
 
@@ -39,7 +39,7 @@
     <tbody>
         <tr>
             <th>bbox</th>
-            <td>The geographic bounding box to search for features in <code>xmin</code>, <code>ymin</code>, <code>mxax</code>, <code>ymax</code> (min longitude, min latitude, max longitude, max latitude) format</td>
+            <td>The geographic bounding box to search for features in <code>xmin</code>, <code>ymin</code>, <code>xmax</code>, <code>ymax</code> (min longitude, min latitude, max longitude, max latitude) format</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Just fix a couple typos I noticed while looking through the docs.
